### PR TITLE
Add parsed PAHO csv data set

### DIFF
--- a/data/PAHO_12_May_2016_Subregions.csv
+++ b/data/PAHO_12_May_2016_Subregions.csv
@@ -1,0 +1,1082 @@
+subregion,country,deaths_among_cases,confirmed_cases,suspected_cases
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,8,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+Andean,Colombia,0,66,75
+Andean,Colombia,0,83,94
+Andean,Colombia,0,66,210
+Latin Caribbean,Haiti,0,0,3
+Andean,Colombia,0,30,324
+Latin Caribbean,Haiti,0,0,0
+Andean,Colombia,0,47,544
+Andean,Colombia,0,30,1105
+Latin Caribbean,Haiti,0,0,0
+Non Latin Caribbean,Suriname,0,11,6
+South Cone,Brazil,0,0,0
+Latin Caribbean,Haiti,0,0,0
+Andean,Colombia,0,51,1183
+Central America,Guatemala,0,1,21
+Latin Caribbean,Haiti,0,0,0
+Central America,Panamá,0,0,0
+Central America,El Salvador,0,0,100
+Andean,Colombia,0,61,1288
+Central America,El Salvador,0,3,348
+Latin Caribbean,Haiti,0,0,0
+North America,Mexico,0,2,0
+South Cone,Paraguay,0,6,0
+Andean,Venezuela,0,4,0
+South Cone,Brazil,3,0,0
+Andean,Colombia,0,78,1637
+Central America,El Salvador,0,0,846
+Latin Caribbean,Haiti,0,0,0
+Andean,Colombia,0,81,1580
+Latin Caribbean,Haiti,0,0,5
+Central America,El Salvador,0,0,914
+Andean,Colombia,0,95,1917
+Latin Caribbean,Haiti,0,0,0
+Central America,Honduras,0,2,0
+Central America,Panamá,0,20,0
+Central America,El Salvador,0,0,753
+Andean,Colombia,0,116,1642
+Latin Caribbean,Haiti,0,0,2
+Central America,Honduras,0,0,55
+Central America,El Salvador,0,0,1172
+Andean,Colombia,0,183,1545
+Central America,El Salvador,0,0,847
+Central America,Guatemala,0,67,33
+Latin Caribbean,Haiti,0,0,2
+Central America,Honduras,0,0,62
+North America,Mexico,0,13,0
+Central America,Panamá,0,2,0
+Latin Caribbean,Puerto Rico,0,9,0
+Non Latin Caribbean,Barbados,0,3,12
+Andean,Bolivia,0,0,0
+Andean,Colombia,0,310,2370
+Andean,Ecuador,0,2,7
+Latin Caribbean,French Guiana,0,7,42
+Latin Caribbean,Haiti,0,5,21
+Central America,Honduras,0,0,960
+Latin Caribbean,Martinique,0,12,415
+Central America,Panamá,0,4,0
+Latin Caribbean,Puerto Rico,0,4,0
+Non Latin Caribbean,Guyana,0,1,0
+Andean,Bolivia,0,1,0
+Andean,Colombia,0,477,2749
+Andean,Ecuador,0,5,7
+Latin Caribbean,French Guiana,0,39,97
+Latin Caribbean,Guadeloupe,0,1,0
+Central America,Guatemala,0,37,52
+Latin Caribbean,Haiti,0,0,23
+Central America,Honduras,0,0,1804
+Latin Caribbean,Martinique,0,0,604
+Latin Caribbean,Puerto Rico,0,4,0
+Latin Caribbean,Saint Martin,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,1,0
+Andean,Colombia,0,539,3933
+Andean,Ecuador,0,6,7
+Latin Caribbean,French Guiana,0,29,106
+Latin Caribbean,Guadeloupe,0,9,37
+Latin Caribbean,Haiti,0,0,192
+Central America,Honduras,0,0,2229
+Latin Caribbean,Martinique,0,0,1064
+Latin Caribbean,Puerto Rico,0,4,0
+Non Latin Caribbean,Curacao,0,1,0
+Andean,Colombia,0,484,5477
+Central America,Costa Rica,0,1,0
+Andean,Ecuador,0,12,7
+Latin Caribbean,French Guiana,0,13,185
+Latin Caribbean,Guadeloupe,0,7,61
+Latin Caribbean,Haiti,0,0,252
+Central America,Honduras,0,0,2374
+Non Latin Caribbean,Jamaica,0,1,66
+Latin Caribbean,Martinique,0,0,1645
+Central America,Nicaragua,0,4,0
+Non Latin Caribbean,Suriname,1,76,330
+Andean,Venezuela,0,0,2062
+Latin Caribbean,Puerto Rico,0,9,0
+Andean,Colombia,0,307,6056
+Central America,Nicaragua,0,27,0
+Non Latin Caribbean,Barbados,0,4,36
+Central America,Nicaragua,0,20,0
+North America,Mexico,0,13,0
+Andean,Venezuela,0,0,0
+Andean,Venezuela,0,0,1
+Andean,Venezuela,0,0,0
+Andean,Venezuela,0,0,0
+Andean,Venezuela,0,0,0
+Andean,Venezuela,0,0,1
+Andean,Venezuela,0,0,0
+Andean,Venezuela,0,4,4
+Andean,Venezuela,0,14,20
+Andean,Venezuela,0,27,17
+Andean,Venezuela,0,27,16
+Andean,Venezuela,0,22,6
+Andean,Venezuela,0,40,237
+Andean,Venezuela,0,40,505
+Andean,Venezuela,0,40,1026
+Andean,Venezuela,0,41,4590
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,0
+Non Latin Caribbean,Barbados,0,0,32
+Non Latin Caribbean,Barbados,0,0,54
+Non Latin Caribbean,Barbados,0,0,74
+Non Latin Caribbean,Barbados,0,0,83
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,230,0
+South Cone,Brazil,0,270,0
+South Cone,Brazil,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,0
+Latin Caribbean,Dominican Republic,0,0,12
+Latin Caribbean,Dominican Republic,0,0,18
+Latin Caribbean,Dominican Republic,0,10,58
+Latin Caribbean,Dominican Republic,0,0,77
+Latin Caribbean,Dominican Republic,0,8,119
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,0
+Andean,Ecuador,0,0,7
+Central America,El Salvador,0,0,0
+Central America,El Salvador,0,0,0
+Central America,El Salvador,0,0,16
+Central America,El Salvador,0,0,12
+Central America,El Salvador,0,0,18
+Central America,El Salvador,0,0,49
+Central America,El Salvador,0,4,1076
+Central America,El Salvador,0,3,1052
+Central America,El Salvador,0,3,895
+Central America,El Salvador,0,3,846
+Central America,El Salvador,0,3,652
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,0,0
+Latin Caribbean,French Guiana,0,11,198
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,0
+Latin Caribbean,Guadeloupe,0,0,24
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,0,0
+Central America,Guatemala,0,7,28
+Central America,Guatemala,0,12,52
+Central America,Guatemala,0,12,59
+Central America,Guatemala,0,12,49
+Central America,Guatemala,0,12,46
+Central America,Guatemala,0,12,51
+Central America,Guatemala,0,11,38
+Central America,Guatemala,0,12,87
+Central America,Guatemala,0,12,88
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Latin Caribbean,Haiti,0,0,0
+Latin Caribbean,Haiti,0,0,0
+Latin Caribbean,Haiti,0,0,291
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,0
+Central America,Honduras,0,0,2559
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,1
+Non Latin Caribbean,Jamaica,0,0,0
+Non Latin Caribbean,Jamaica,0,0,2
+Non Latin Caribbean,Jamaica,0,0,3
+Non Latin Caribbean,Jamaica,0,0,5
+Non Latin Caribbean,Jamaica,0,0,11
+Non Latin Caribbean,Jamaica,0,1,15
+Non Latin Caribbean,Jamaica,0,0,162
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,0
+Latin Caribbean,Martinique,0,0,179
+Latin Caribbean,Martinique,0,0,1189
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,0,0
+North America,Mexico,0,3,0
+North America,Mexico,0,16,0
+North America,Mexico,0,30,0
+North America,Mexico,0,15,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Nicaragua,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,4,0
+Central America,Panamá,0,0,0
+Central America,Panamá,0,5,0
+Central America,Panamá,0,8,0
+Central America,Panamá,0,3,0
+Central America,Panamá,0,4,0
+Central America,Panamá,0,4,0
+Central America,Panamá,0,14,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,0,0
+Latin Caribbean,Puerto Rico,0,57,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,1,0
+Latin Caribbean,Saint Martin,0,0,0
+Latin Caribbean,Saint Martin,0,0,3
+Latin Caribbean,Saint Martin,0,5,14
+Latin Caribbean,Saint Martin,0,2,18
+Non Latin Caribbean,Suriname,0,3,1
+Non Latin Caribbean,Suriname,0,5,2
+Non Latin Caribbean,Suriname,0,3,3
+Non Latin Caribbean,Suriname,0,3,1
+Non Latin Caribbean,Suriname,0,11,3
+Non Latin Caribbean,Suriname,0,11,46
+Non Latin Caribbean,Suriname,0,18,29
+Non Latin Caribbean,Suriname,0,20,61
+Non Latin Caribbean,Suriname,0,33,60
+Non Latin Caribbean,Suriname,0,14,59
+Non Latin Caribbean,Suriname,0,22,37
+Non Latin Caribbean,Suriname,0,17,38
+Non Latin Caribbean,Suriname,2,68,53
+Non Latin Caribbean,Suriname,1,53,172
+Non Latin Caribbean,Suriname,0,85,288
+Non Latin Caribbean,Suriname,0,32,307
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,Aruba,0,4,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Bonaire,0,1,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Central America,Nicaragua,0,26,0
+Non Latin Caribbean,Trinidad and Tobago,0,1,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,526,0
+Central America,Panamá,0,14,0
+Central America,Panamá,0,20,0
+Latin Caribbean,French Guiana,0,11,203
+Latin Caribbean,Guadeloupe,0,8,78
+Latin Caribbean,Martinique,0,0,916
+Latin Caribbean,Saint Martin,0,9,9
+Andean,Colombia,0,107,5342
+Central America,El Salvador,0,3,483
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,5,0
+Central America,Costa Rica,0,2,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,United States Virgin Islands,0,1,0
+Non Latin Caribbean,United States Virgin Islands,0,2,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,1,0
+Non Latin Caribbean,Sint Maarten,0,1,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,1,0
+Latin Caribbean,Dominican Republic,0,0,103
+Latin Caribbean,French Guiana,0,3,227
+Latin Caribbean,Guadeloupe,0,10,168
+Latin Caribbean,Martinique,0,0,1548
+Latin Caribbean,Saint Martin,0,8,20
+Andean,Colombia,0,33,4699
+North America,Mexico,0,27,0
+Central America,Nicaragua,0,14,0
+Central America,El Salvador,0,3,291
+Non Latin Caribbean,Barbados,0,0,2
+Andean,Ecuador,0,14,7
+Andean,Ecuador,0,1,7
+Latin Caribbean,Dominican Republic,0,0,95
+Non Latin Caribbean,Barbados,0,0,23
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+Andean,Colombia,0,7,3894
+Non Latin Caribbean,Suriname,0,39,227
+North America,Mexico,0,22,0
+Central America,Honduras,0,0,1086
+Andean,Colombia,0,53,1
+Andean,Colombia,0,37,1
+Andean,Colombia,0,17,1
+Andean,Colombia,0,24,0
+Andean,Colombia,0,30,5
+Andean,Colombia,0,44,9
+Andean,Colombia,0,51,13
+Andean,Colombia,0,97,42
+Latin Caribbean,Martinique,0,0,1640
+Latin Caribbean,Guadeloupe,0,31,79
+Central America,Honduras,0,0,2166
+Central America,Honduras,0,0,1514
+Latin Caribbean,French Guiana,0,16,414
+Latin Caribbean,Saint Martin,0,2,37
+Andean,Ecuador,0,0,7
+Central America,El Salvador,0,3,205
+Central America,Panamá,0,10,0
+Andean,Venezuela,0,44,3656
+Andean,Venezuela,0,49,4658
+Latin Caribbean,Dominican Republic,0,0,111
+Non Latin Caribbean,Trinidad and Tobago,0,0,0
+Andean,Bolivia,0,1,0
+Central America,Guatemala,0,14,51
+Non Latin Caribbean,Dominica,0,0,0
+Latin Caribbean,Cuba,0,0,0
+South Cone,Paraguay,0,0,0
+Andean,Bolivia,0,0,0
+Andean,Bolivia,0,10,0
+Latin Caribbean,Haiti,0,0,226
+Latin Caribbean,Puerto Rico,0,72,0
+Non Latin Caribbean,Suriname,0,0,138
+Non Latin Caribbean,United States Virgin Islands,0,2,0
+Central America,Nicaragua,0,16,0
+Latin Caribbean,Puerto Rico,0,41,0
+Central America,El Salvador,0,3,167
+Central America,Guatemala,0,13,129
+Central America,Guatemala,0,13,77
+Non Latin Caribbean,Trinidad and Tobago,0,2,0
+Central America,El Salvador,0,3,0
+Central America,El Salvador,0,3,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Non Latin Caribbean,Dominica,0,0,0
+Central America,Panamá,0,13,0
+Latin Caribbean,Guadeloupe,0,11,197
+Latin Caribbean,French Guiana,0,24,418
+North America,Mexico,0,8,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Latin Caribbean,Cuba,0,0,0
+Andean,Colombia,0,20,3865
+Non Latin Caribbean,Dominica,0,1,0
+Latin Caribbean,Cuba,0,0,0
+Central America,Honduras,0,0,1040
+South Cone,Paraguay,0,0,0
+Latin Caribbean,Saint Martin,0,3,19
+Latin Caribbean,Martinique,0,0,1710
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+Andean,Ecuador,0,13,7
+Latin Caribbean,Dominican Republic,0,0,107
+South Cone,Brazil,0,0,0
+Central America,Costa Rica,0,0,0
+Latin Caribbean,Haiti,0,0,126
+Central America,Guatemala,0,14,54
+Non Latin Caribbean,Suriname,0,0,121
+Non Latin Caribbean,United States Virgin Islands,0,1,0
+Non Latin Caribbean,Dominica,0,0,4
+Latin Caribbean,Cuba,0,0,0
+Central America,Panamá,0,14,0
+South Cone,Paraguay,0,1,0
+Central America,El Salvador,0,3,111
+Non Latin Caribbean,Trinidad and Tobago,0,1,0
+South Cone,Brazil,0,0,0
+Latin Caribbean,Guadeloupe,0,20,106
+Latin Caribbean,French Guiana,0,48,375
+Andean,Colombia,0,21,3503
+Central America,Honduras,0,0,687
+Latin Caribbean,Puerto Rico,0,11,0
+Latin Caribbean,Haiti,0,0,190
+Latin Caribbean,Haiti,0,0,305
+Latin Caribbean,Dominican Republic,0,13,122
+Latin Caribbean,Haiti,0,0,139
+Latin Caribbean,Martinique,0,0,1650
+Latin Caribbean,Saint Martin,0,0,24
+Andean,Ecuador,0,0,7
+Central America,Nicaragua,0,10,0
+North America,Mexico,0,11,0
+Non Latin Caribbean,Suriname,0,0,129
+Non Latin Caribbean,Dominica,0,0,6
+Latin Caribbean,Cuba,0,1,0
+Non Latin Caribbean,United States Virgin Islands,0,3,0
+Central America,Panamá,0,22,0
+Latin Caribbean,Guadeloupe,0,37,44
+Latin Caribbean,French Guiana,0,15,505
+Latin Caribbean,Puerto Rico,0,72,0
+Latin Caribbean,Puerto Rico,0,67,0
+Latin Caribbean,Martinique,0,0,1730
+Latin Caribbean,Saint Martin,0,0,10
+Andean,Colombia,0,18,2792
+Andean,Ecuador,0,10,2
+Latin Caribbean,Dominican Republic,0,12,169
+Non Latin Caribbean,Trinidad and Tobago,0,1,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+North America,Mexico,0,23,0
+Central America,Nicaragua,0,12,0
+Latin Caribbean,Puerto Rico,0,22,0
+Central America,El Salvador,0,3,75
+Non Latin Caribbean,Suriname,0,0,76
+Non Latin Caribbean,United States Virgin Islands,0,2,0
+Central America,Panamá,0,26,0
+Non Latin Caribbean,Trinidad and Tobago,0,4,0
+Non Latin Caribbean,United States Virgin Islands,0,1,0
+Latin Caribbean,Guadeloupe,0,5,106
+Latin Caribbean,French Guiana,0,83,420
+Latin Caribbean,Martinique,0,0,1100
+Latin Caribbean,Saint Martin,0,6,3
+Andean,Colombia,0,19,2281
+Central America,Panamá,0,20,0
+Central America,El Salvador,0,0,63
+North America,Mexico,0,18,0
+Non Latin Caribbean,Suriname,0,3,226
+Andean,Ecuador,0,6,4
+Central America,Nicaragua,0,2,0
+Central America,El Salvador,0,0,43
+Central America,El Salvador,0,0,44
+Latin Caribbean,Dominican Republic,0,12,99
+Non Latin Caribbean,Suriname,0,0,14
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,0,0
+Non Latin Caribbean,Saint Lucia,0,2,0
+Andean,Colombia,0,19,3509
+Latin Caribbean,Guadeloupe,0,52,190
+Latin Caribbean,French Guiana,0,56,430
+Latin Caribbean,Martinique,0,0,1260
+Latin Caribbean,Saint Martin,0,6,3
+Central America,Nicaragua,0,4,0
+North America,Mexico,0,21,0
+North America,Mexico,0,17,0
+Central America,Honduras,0,0,550
+Central America,Honduras,0,0,93
+Central America,Honduras,0,0,323
+Central America,Panamá,0,13,0
+Non Latin Caribbean,United States Virgin Islands,0,1,0
+Andean,Ecuador,0,2,63
+Latin Caribbean,Puerto Rico,0,64,0
+Non Latin Caribbean,Trinidad and Tobago,0,2,0
+Non Latin Caribbean,Trinidad and Tobago,0,2,0
+Latin Caribbean,Dominican Republic,0,1,159
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,0,0
+Central America,Belize,0,1,0
+Non Latin Caribbean,Suriname,0,0,9
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,0,0
+Non Latin Caribbean,Guyana,0,5,0
+Non Latin Caribbean,Dominica,0,1,1
+Non Latin Caribbean,Dominica,0,4,7
+Non Latin Caribbean,Dominica,0,11,13
+Non Latin Caribbean,Dominica,0,1,44
+Latin Caribbean,Guadeloupe,0,48,245
+Latin Caribbean,French Guiana,0,56,470
+Latin Caribbean,Martinique,0,0,1340
+Latin Caribbean,Saint Martin,0,1,15
+Non Latin Caribbean,Suriname,0,0,13
+Andean,Venezuela,0,0,4011
+Andean,Venezuela,0,0,3168
+Andean,Venezuela,0,0,2671
+Andean,Venezuela,0,0,2100
+Andean,Venezuela,0,0,1169
+Andean,Venezuela,0,0,1306
+Andean,Colombia,0,17,3020
+Central America,Honduras,0,0,440
+Latin Caribbean,Puerto Rico,0,114,0
+Central America,Nicaragua,0,4,0
+Andean,Ecuador,0,1,1
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,0,0
+Non Latin Caribbean,Aruba,0,13,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,0,0
+Non Latin Caribbean,Curacao,0,72,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,0,0
+Non Latin Caribbean,Sint Maarten,0,5,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,0,0
+Non Latin Caribbean,Bonaire,0,2,0
+Non Latin Caribbean,United States Virgin Islands,0,0,0
+Non Latin Caribbean,Trinidad and Tobago,0,3,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,91387
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,0
+Andean,Colombia,0,17,2654
+Central America,El Salvador,0,3,134
+Central America,El Salvador,0,0,69
+Non Latin Caribbean,Jamaica,0,1,81
+Non Latin Caribbean,Jamaica,0,0,83
+Non Latin Caribbean,Jamaica,0,0,67
+Non Latin Caribbean,Jamaica,0,2,73
+Non Latin Caribbean,Jamaica,0,1,43
+Non Latin Caribbean,Jamaica,0,0,25
+Non Latin Caribbean,Jamaica,0,0,5
+Non Latin Caribbean,Jamaica,0,0,2
+Non Latin Caribbean,Jamaica,0,0,1
+Non Latin Caribbean,Jamaica,0,0,1
+Non Latin Caribbean,Jamaica,0,2,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,0,0
+Central America,Costa Rica,0,1,0
+Central America,Costa Rica,0,2,0
+Latin Caribbean,Guadeloupe,0,67,346
+Latin Caribbean,French Guiana,0,72,510
+Latin Caribbean,Martinique,0,0,1410
+Non Latin Caribbean,United States Virgin Islands,0,2,0
+Latin Caribbean,Saint Martin,0,11,8
+North America,Mexico,0,13,0
+Central America,Nicaragua,0,11,0
+Latin Caribbean,Puerto Rico,0,76,0
+Latin Caribbean,Dominican Republic,0,0,172
+Latin Caribbean,Dominican Republic,0,17,253
+Central America,Honduras,0,0,475
+Non Latin Caribbean,Suriname,0,0,25
+Non Latin Caribbean,Dominica,0,0,49
+Andean,Ecuador,0,3,16
+Andean,Ecuador,0,2,15
+Central America,Nicaragua,0,4,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,0
+South Cone,Paraguay,0,0,102
+Central America,Honduras,0,0,342
+North America,Mexico,0,12,0
+Non Latin Caribbean,Suriname,0,0,15
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,0,0
+Non Latin Caribbean,Saint Barthelemy,0,1,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,0,0
+Andean,Peru,0,1,0
+Non Latin Caribbean,United States Virgin Islands,0,5,0
+Andean,Peru,0,2,0
+Andean,Colombia,0,17,2075
+Latin Caribbean,Puerto Rico,1,81,0
+Central America,Nicaragua,0,13,0
+Latin Caribbean,Guadeloupe,0,106,418
+Latin Caribbean,French Guiana,0,0,260
+Latin Caribbean,Martinique,0,0,1580
+Latin Caribbean,Saint Martin,0,7,29
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,0,0
+Non Latin Caribbean,Saint Vincent and the Grenadines,0,1,0
+Non Latin Caribbean,Suriname,0,0,1
+Non Latin Caribbean,Suriname,0,0,2
+Non Latin Caribbean,Suriname,0,0,0
+Non Latin Caribbean,Dominica,0,0,5
+South Cone,Brazil,0,0,0
+South Cone,Brazil,0,0,28774
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,0,0
+Non Latin Caribbean,Grenada,0,1,0
+Central America,Panamá,0,0,0


### PR DESCRIPTION
This is the data from `/paho/zika-cases.xls`, which originated from
http://ais.paho.org/phip/viz/ed_zika_cases.asp

It represents the cmulatuve Zika suspected and confirmed cases reported by
countries and territories in the Americas, 2015-2016.

Updated as of 5 May 2016.
